### PR TITLE
Add MessageBuilder Payload Methods

### DIFF
--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -95,7 +95,7 @@ class MessageBuilder:
             payload.actions.append("dismissed")
 
         embed = discord.Embed(
-            colour=embed_color or item.subreddit.banhammer.embed_color
+            colour=embed_color or payload.item.subreddit.banhammer.embed_color
         )
 
         author_name = discord.utils.escape_markdown(await payload.item.get_author_name())

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -2,6 +2,7 @@ import discord
 
 from ..const import BOT_DISCLAIMER
 from .item import RedditItem
+from .reaction import ReactionPayload
 
 
 class MessageBuilder:
@@ -77,3 +78,30 @@ class MessageBuilder:
     def format_reply(self, item: RedditItem, reply: str):
         disclaimer = BOT_DISCLAIMER.format(item.subreddit.get_contact_url())
         return f"{reply}\n\n{disclaimer}"
+
+    async def get_payload_message(self, payload: ReactionPayload):
+        if not payload.actions:
+            payload.actions.append("dismissed")
+
+        user = discord.utils.escape_markdown(payload.user)
+        author_name = discord.utils.escape_markdown(await payload.item.get_author_name())
+        url = discord.utils.escape_markdown(payload.item.url)
+
+        return f"**{payload.item.type.title()} {' and '.join(payload.actions)} by {user}!**\n\n" \
+               f"{payload.item.type.title()} by /u/{author_name}:\n\n{url}"
+
+    async def get_payload_embed(self, payload: ReactionPayload, embed_color: discord.Color = None):
+        if not payload.actions:
+            payload.actions.append("dismissed")
+
+        embed = discord.Embed(
+            colour=embed_color or item.subreddit.banhammer.embed_color
+        )
+
+        author_name = discord.utils.escape_markdown(await payload.item.get_author_name())
+        url = discord.utils.escape_markdown(payload.item.url)
+
+        embed.set_author(name=f"{payload.item.type.title()} {' and '.join(payload.actions)} by {payload.user}!")
+        embed.description = f"[{payload.item.type.title()}]({url}) by /u/{author_name}."
+
+        return embed

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -35,7 +35,7 @@ class MessageBuilder:
             if item.source == "reports":
                 title = f"{item.type.title()} reported on /r/{item.subreddit} by /u/{await item.get_author_name()}!"
             else:
-                title = f"New {item.type} on /r/{item.subreddit} by /u/{author_name}!"
+                title = f"New {item.type} on /r/{item.subreddit} by /u/{await item.get_author_name()}!"
         elif item.type == "modmail":
             title = f"New message in modmail conversation '{item.item.conversation.subject}' on /r/{item.subreddit} by /u/{await item.get_author_name()}!"
         else:

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -99,9 +99,8 @@ class MessageBuilder:
         )
 
         author_name = discord.utils.escape_markdown(await payload.item.get_author_name())
-        url = discord.utils.escape_markdown(payload.item.url)
 
         embed.set_author(name=f"{payload.item.type.title()} {' and '.join(payload.actions)} by {payload.user}!")
-        embed.description = f"[{payload.item.type.title()}]({url}) by /u/{author_name}."
+        embed.description = f"[{payload.item.type.title()}]({payload.item.url}) by /u/{author_name}."
 
         return embed

--- a/banhammer/models/reaction.py
+++ b/banhammer/models/reaction.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Union
 
+import discord
 from apraw.models import (Comment, ModmailConversation, ModmailMessage,
                           Submission)
 
@@ -11,9 +12,9 @@ from .item import RedditItem
 
 class ReactionPayload:
 
-    def __init__(self, user: str = "Banhammer"):
-        self.item = None
+    def __init__(self, user: str = "Banhammer", item: RedditItem = None):
         self.user = user
+        self.item = item
         self.actions = list()
         self.approved = False
         self.reply = ""
@@ -27,11 +28,10 @@ class ReactionPayload:
         self.reply = reply
 
     async def get_message(self):
-        if len(self.actions) == 0:
-            self.actions.append("dismissed")
-        return f"**{self.item.type.title()} {' and '.join(self.actions)} by {self.user}!**\n\n" \
-               f"{self.item.type.title()} by /u/{await self.item.get_author_name()}:\n\n" \
-               f"{self.item.url}"
+        return await self.item.subreddit.banhammer.message_builder.get_payload_message(self)
+
+    async def get_embed(self):
+        return await self.item.subreddit.banhammer.message_builder.get_payload_embed(self)
 
     def __repr__(self):
         return f"<ReactionPayload item={self.item} approved={self.approved} actions={self.actions}>"


### PR DESCRIPTION
Fixes #29 

 - Add `MessageBuilder.get_payload_message()` and `get_payload_embed()`.
 - Add `Payload.get_embed()` and forward `get_message()` to `class MessageBuilder`.
 - Fix usage of `author_name` in `class MessageBuilder`.