### PR TITLE
Rich Embeds

### DIFF
--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -62,6 +62,9 @@ class MessageBuilder:
                 value=escape_markdown(item.item.title),
                 inline=False)
 
+            if item.item.link_flair_text:
+                embed.description = f"Flair: `{item.item.link_flair_text}`"
+
             if item.item.is_self:
                 embed.add_field(name="Body", value=item.body, inline=False)
             elif "i.redd.it" in item.item.url or any(item.item.url.endswith(ext) for ext in (".jpg", ".jpeg", ".png", ".gif")):

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -64,7 +64,7 @@ class MessageBuilder:
 
             if item.item.is_self:
                 embed.add_field(name="Body", value=item.body, inline=False)
-            elif "i.redd.it" in item.item.url:
+            elif "i.redd.it" in item.item.url or any(item.item.url.endswith(ext) for ext in (".jpg", ".jpeg", ".png", ".gif")):
                 embed.set_image(url=item.item.url)
             elif not item.item._data.get("poll_data", None):
                 embed.add_field(

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -1,6 +1,10 @@
-import discord
+from datetime import datetime
 
-from ..const import BOT_DISCLAIMER
+import discord
+from apraw.models import ModmailConversation, ModmailMessage
+from discord.utils import escape_markdown
+
+from ..const import BOT_DISCLAIMER, logger
 from .item import RedditItem
 from .reaction import ReactionPayload
 
@@ -9,20 +13,20 @@ class MessageBuilder:
 
     async def get_item_message(self, item: RedditItem):
         if item.type in ["submission", "comment"]:
-            author_name = discord.utils.escape_markdown(await item.get_author_name())
-            subreddit = discord.utils.escape_markdown(str(item.subreddit))
+            author_name = escape_markdown(await item.get_author_name())
+            subreddit = escape_markdown(str(item.subreddit))
             return f"New {item.type} on /r/{subreddit} by /u/{author_name}!\n\n" + \
                 f"{item.url}\n\n" + \
                 f"**Title:** {item.item.title}\n**Body:**\n{item.body}"
         elif item.type == "modmail":
-            author_name = discord.utils.escape_markdown(await item.get_author_name())
-            subreddit = discord.utils.escape_markdown(str(item.subreddit))
-            subject = discord.utils.escape_markdown(item.item.conversation.subject)
+            author_name = escape_markdown(await item.get_author_name())
+            subreddit = escape_markdown(str(item.subreddit))
+            subject = escape_markdown(item.item.conversation.subject)
             return f"New message in modmail conversation '{subject}' on /r/{subreddit} by /u/{author_name}!" + \
                 f"\n\n{item.body}"
         else:
-            author_name = discord.utils.escape_markdown(await item.get_author_name())
-            subreddit = discord.utils.escape_markdown(str(item.subreddit))
+            author_name = escape_markdown(await item.get_author_name())
+            subreddit = escape_markdown(str(item.subreddit))
             return f"New action taken by /u/{author_name} on /r/{subreddit}: `{item.body}`"
 
     async def get_item_embed(self, item: RedditItem, embed_color: discord.Color = None):
@@ -30,7 +34,13 @@ class MessageBuilder:
             colour=embed_color or item.subreddit.banhammer.embed_color
         )
 
-        title = ""
+        if isinstance(item.item, ModmailConversation):
+            embed.timestamp = datetime.utcfromtimestamp(item.item.last_updated)
+        elif isinstance(item.item, ModmailMessage):
+            embed.timestamp = datetime.utcfromtimestamp(item.item.conversation.last_updated)
+        else:
+            embed.timestamp = item.item.created_utc
+
         if item.type in ["submission", "comment"]:
             if item.source == "reports":
                 title = f"{item.type.title()} reported on /r/{item.subreddit} by /u/{await item.get_author_name()}!"
@@ -41,28 +51,56 @@ class MessageBuilder:
         else:
             title = f"New action taken by /u/{await item.get_author_name()} on /r/{item.subreddit}!"
 
-        embed.set_author(name=title, url=item.url if item.url else discord.Embed.Empty)
+        subreddit = await item.subreddit.get_subreddit()
+        embed.set_author(name=title,
+                         url=item.url or discord.Embed.Empty,
+                         icon_url=subreddit.community_icon or discord.Embed.Empty)
 
         if item.type == "submission":
             embed.add_field(
                 name="Title",
-                value=discord.utils.escape_markdown(item.item.title),
+                value=escape_markdown(item.item.title),
                 inline=False)
+
             if item.item.is_self:
                 embed.add_field(name="Body", value=item.body, inline=False)
-            else:
+            elif "i.redd.it" in item.item.url:
+                embed.set_image(url=item.item.url)
+            elif not item.item._data.get("poll_data", None):
                 embed.add_field(
                     name="URL",
-                    value=discord.utils.escape_markdown(item.item.url),
+                    value=escape_markdown(item.item.url),
                     inline=False)
+
+            if item.item._data.get("poll_data", None):
+                options = [
+                    f"◽ {escape_markdown(option['text'])}" for option in item.item.poll_data["options"]]
+                embed.add_field(name="Poll", value="\n".join(options), inline=False)
+            elif item.item._data.get("media_metadata", None):
+                for _, media in item.item.media_metadata.items():
+                    if media["e"] == "Image":
+                        added = False
+                        if isinstance(media.get("s", None), dict) and "u" in media["s"]:
+                            embed.set_image(url=media["s"]["u"])
+                            added = True
+                        elif isinstance(media.get("p", None), list):
+                            try:
+                                embed.set_image(url=media["p"][-1]["u"])
+                                added = True
+                            except BaseException:
+                                logger.warning(f"Unexpected media metadata: {media}")
+                        else:
+                            logger.warning(f"Unexpected media metadata: {media}")
+
+                        if added:
+                            break
+
             if item.source == "reports":
                 embed.add_field(
                     name="Reports",
                     value="\n".join(f"{r[1]} {r[0]}" for r in item.item.user_reports),
                     inline=False)
-        elif item.type == "comment":
-            embed.description = item.body
-        elif item.type == "modmail":
+        elif item.type in ("comment", "modmail"):
             embed.description = item.body
         elif item.type == "mod action":
             embed.description = f"Action: `{item.body}`"
@@ -83,9 +121,9 @@ class MessageBuilder:
         if not payload.actions:
             payload.actions.append("dismissed")
 
-        user = discord.utils.escape_markdown(payload.user)
-        author_name = discord.utils.escape_markdown(await payload.item.get_author_name())
-        url = discord.utils.escape_markdown(payload.item.url)
+        user = escape_markdown(payload.user)
+        author_name = escape_markdown(await payload.item.get_author_name())
+        url = escape_markdown(payload.item.url)
 
         return f"**{payload.item.type.title()} {' and '.join(payload.actions)} by {user}!**\n\n" \
                f"{payload.item.type.title()} by /u/{author_name}:\n\n{url}"
@@ -98,7 +136,9 @@ class MessageBuilder:
             colour=embed_color or payload.item.subreddit.banhammer.embed_color
         )
 
-        author_name = discord.utils.escape_markdown(await payload.item.get_author_name())
+        embed.timestamp = datetime.utcnow()
+
+        author_name = escape_markdown(await payload.item.get_author_name())
 
         embed.set_author(name=f"{payload.item.type.title()} {' and '.join(payload.actions)} by {payload.user}!")
         embed.description = f"[{payload.item.type.title()}]({payload.item.url}) by /u/{author_name}."


### PR DESCRIPTION
Closes #36 

This pull request adds additional content to embeds generated in the `class MessageBuilder` including:

 - Polls are rendered directly in the following format:

   ![image](https://user-images.githubusercontent.com/32235074/88637538-96293980-d0ba-11ea-85e9-3b797997a7c4.png)

 - Add timestamps for when items were created, as well as when payloads were generated.
 - Add support for third-party image links and Reddit galleries, using first image preview.
 - Add display of flairs when present, as well as subreddit community icon as the author icon:

   ![image](https://user-images.githubusercontent.com/32235074/88638439-c91ffd00-d0bb-11ea-8918-2fdb95f84089.png)
