### PR TITLE
Add Subreddit Reactions Embed, Fix Import

### DIFF
--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -8,11 +8,9 @@ import apraw
 import discord
 from apraw.utils import ExponentialCounter
 
-from .const import logger
+from .const import BANHAMMER_PURPLE, logger
 from .models import MessageBuilder, ReactionHandler, RedditItem, Subreddit
 from .utils import reddit_helper
-
-banhammer_purple = discord.Colour(0).from_rgb(207, 206, 255)
 
 
 class Banhammer:
@@ -20,7 +18,7 @@ class Banhammer:
     The main Banhammer class that manages the event loop to poll Reddit and forward items to configured callables.
     """
 
-    def __init__(self, reddit: apraw.Reddit, max_loop_time: int = 16, bot: discord.Client = None, embed_color: discord.Colour = banhammer_purple,
+    def __init__(self, reddit: apraw.Reddit, max_loop_time: int = 16, bot: discord.Client = None, embed_color: discord.Colour = BANHAMMER_PURPLE,
                  change_presence: bool = False, message_builder: MessageBuilder = MessageBuilder(), reaction_handler: ReactionHandler = ReactionHandler()):
         """
         Create a Banhammer instance.
@@ -388,40 +386,39 @@ class Banhammer:
         s = str(c) if not isinstance(c, discord.Embed) else json.dumps(c.to_dict())
         return await reddit_helper.get_item(self.reddit, self.subreddits, s)
 
-    def get_reactions_embed(self):
+    def get_reactions_embed(self, embed_color: discord.Color = None):
         """
         Load an embed with all the configured reactions per subreddit.
+
+        Parameters
+        ----------
+        embed_color : discord.Color
+            The color to be used for the embed, if not specified, the
+            :attr:`~banhammer.Banhammer.embed_color` is used.
 
         Returns
         -------
         embed: discord.Embed
             The embed listing all the configured reactions per subreddit.
         """
-        embed = discord.Embed(
-            colour=self.embed_color
-        )
-        embed.title = "Configured reactions"
-        for sub in self.subreddits:
-            embed.add_field(name="/r/" + str(sub),
-                            value="\n".join([repr(r) for r in sub.reactions]),
-                            inline=False)
-        return embed
+        return self.message_builder.get_reactions_embed(self.subreddits)
 
-    def get_subreddits_embed(self):
+    def get_subreddits_embed(self, embed_color: discord.Color = None):
         """
         Load an embed with all the configured subreddits and their enabled streams.
+
+        Parameters
+        ----------
+        embed_color : discord.Color
+            The color to be used for the embed, if not specified, the
+            :attr:`~banhammer.Banhammer.embed_color` is used.
 
         Returns
         -------
         embed: discord.Embed
             The embed of all the subreddits and their enabled streams.
         """
-        embed = discord.Embed(
-            colour=self.embed_color
-        )
-        embed.title = "Subreddits' statuses"
-        embed.description = "\n".join([s.status for s in self.subreddits])
-        return embed
+        return self.message_builder.get_subreddits_embed(self.subreddits)
 
     def run(self):
         """

--- a/banhammer/const.py
+++ b/banhammer/const.py
@@ -13,5 +13,7 @@ BOT_FOOTER = f"^({BOT_VERSION_TEXT} | /r/BanhammerBot | Join us on) ^[Discord](h
 BOT_DISCLAIMER = "*This action was performed by the users of the [Banhammer.py](https://www.github.com/Dan6erbond/Banhammer.py) framework. " \
                  "Please [contact the moderators of this subreddit]({}) if you have any questions or concerns.*\n\n" + BOT_FOOTER
 
+BANHAMMER_PURPLE = discord.Colour(0).from_rgb(207, 206, 255)
+
 logging.root.setLevel(logging.NOTSET)
 logger = logging.getLogger("banhammer")

--- a/banhammer/const.py
+++ b/banhammer/const.py
@@ -1,5 +1,7 @@
 import logging
 
+import discord
+
 __title__ = "banhammer"
 __author__ = "Dan6erbond"
 __license__ = "GNU General Public License v3 (GPLv3)"

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -203,4 +203,5 @@ class MessageBuilder:
             colour=embed_color or subreddits[0].banhammer.embed_color if subreddits else BANHAMMER_PURPLE
         )
         embed.timestamp = datetime.utcnow()
-        return
+        return embed
+

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -114,12 +114,12 @@ class MessageBuilder:
 
     def get_ban_message(self, item: RedditItem, ban_duration: int):
         ban_type = "permanent" if not ban_duration else "temporary"
-        disclaimer = BOT_DISCLAIMER.format(item.subreddit.get_contact_url())
+        disclaimer = BOT_DISCLAIMER.format(item.subreddit.contact_url)
         return f"Our moderator team has reviewed [this post]({item.url}) and decided to give you a {ban_type} ban. " \
                f"If you wish to appeal this ban, please respond to this message.\n\n{disclaimer}"
 
     def format_reply(self, item: RedditItem, reply: str):
-        disclaimer = BOT_DISCLAIMER.format(item.subreddit.get_contact_url())
+        disclaimer = BOT_DISCLAIMER.format(item.subreddit.contact_url)
         return f"{reply}\n\n{disclaimer}"
 
     async def get_payload_message(self, payload: ReactionPayload):

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -1,12 +1,14 @@
 from datetime import datetime
+from typing import List
 
 import discord
 from apraw.models import ModmailConversation, ModmailMessage
 from discord.utils import escape_markdown
 
-from ..const import BOT_DISCLAIMER, logger
+from ..const import BANHAMMER_PURPLE, BOT_DISCLAIMER, logger
 from .item import RedditItem
 from .reaction import ReactionPayload
+from .subreddit import Subreddit
 
 
 class MessageBuilder:
@@ -147,3 +149,53 @@ class MessageBuilder:
         embed.description = f"[{payload.item.type.title()}]({payload.item.url}) by /u/{author_name}."
 
         return embed
+
+    def get_reactions_embed(self, subreddits: List[Subreddit], embed_color: discord.Color = None):
+        """
+        Load an embed with all the configured reactions per subreddit.
+
+        Parameters
+        ----------
+        subreddits : List[Subreddit]
+            The subreddits to be included in the overview.
+        embed_color : discord.Color
+            The color to be used for the embed, if not specified, the
+            :attr:`~banhammer.Banhammer.embed_color` is used.
+
+        Returns
+        -------
+        embed: discord.Embed
+            The embed listing all the configured reactions per subreddit.
+        """
+        embed = discord.Embed(
+            title="Configured reactions",
+            colour=embed_color or subreddits[0].banhammer.embed_color if subreddits else BANHAMMER_PURPLE
+        )
+        for sub in subreddits:
+            embed.add_field(name="/r/" + str(sub),
+                            value="\n".join([repr(r) for r in sub.reactions]),
+                            inline=False)
+        return embed
+
+    def get_subreddits_embed(self, subreddits: List[Subreddit], embed_color: discord.Color = None):
+        """
+        Load an embed with all the configured subreddits and their enabled streams.
+
+        Parameters
+        ----------
+        subreddits : List[Subreddit]
+            The subreddits to be included in the overview.
+        embed_color : discord.Color
+            The color to be used for the embed, if not specified, the
+            :attr:`~banhammer.Banhammer.embed_color` is used.
+
+        Returns
+        -------
+        embed: discord.Embed
+            The embed of all the subreddits and their enabled streams.
+        """
+        return discord.Embed(
+            title="Subreddits' statuses",
+            description="\n".join([s.status for s in subreddits]),
+            colour=embed_color or subreddits[0].banhammer.embed_color if subreddits else BANHAMMER_PURPLE
+        )

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -219,7 +219,7 @@ class MessageBuilder:
             icon_url=sub.community_icon or discord.Embed.Empty)
 
         fields = list()
-        for reaction in sub.reactions:
+        for reaction in subreddit.reactions:
             text = repr(reaction).replace(str(reaction) + " | ", "")
             if reaction.reply:
                 text.replace(" | reply", "")

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -205,3 +205,29 @@ class MessageBuilder:
         embed.timestamp = datetime.utcnow()
         return embed
 
+    async def get_subreddit_reactions_embed(self, subreddit: Subreddit, embed_color: discord.Color = None):
+        embed = discord.Embed(
+            colour=embed_color or subreddit.banhammer.embed_color
+        )
+
+        embed.timestamp = datetime.utcnow()
+
+        sub = await subreddit.get_subreddit()
+        embed.set_author(
+            name=f"/r/{subreddit} Configured Reactions",
+            url=f"https://www.reddit.com/r/{subreddit}/wiki/banhammer-reactions",
+            icon_url=sub.community_icon or discord.Embed.Empty)
+
+        fields = list()
+        for reaction in sub.reactions:
+            text = repr(reaction).replace(str(reaction) + " | ", "")
+            if reaction.reply:
+                text.replace(" | reply", "")
+                text += f"\n\n**Reply**\n>>> {reaction.reply}"
+                fields.append({"name": str(reaction), "value": text})
+            else:
+                fields = [{"name": str(reaction), "value": text}, *fields]
+        for field in fields:
+            embed.add_field(**field)
+
+        return embed

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -138,6 +138,7 @@ class MessageBuilder:
             payload.actions.append("dismissed")
 
         embed = discord.Embed(
+            description=f"[{payload.item.type.title()}]({payload.item.url}) by /u/{author_name}.",
             colour=embed_color or payload.item.subreddit.banhammer.embed_color
         )
 
@@ -146,7 +147,6 @@ class MessageBuilder:
         author_name = escape_markdown(await payload.item.get_author_name())
 
         embed.set_author(name=f"{payload.item.type.title()} {' and '.join(payload.actions)} by {payload.user}!")
-        embed.description = f"[{payload.item.type.title()}]({payload.item.url}) by /u/{author_name}."
 
         return embed
 

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -171,6 +171,9 @@ class MessageBuilder:
             title="Configured reactions",
             colour=embed_color or subreddits[0].banhammer.embed_color if subreddits else BANHAMMER_PURPLE
         )
+
+        embed.timestamp = datetime.utcnow()
+
         for sub in subreddits:
             embed.add_field(name="/r/" + str(sub),
                             value="\n".join([repr(r) for r in sub.reactions]),
@@ -194,8 +197,10 @@ class MessageBuilder:
         embed: discord.Embed
             The embed of all the subreddits and their enabled streams.
         """
-        return discord.Embed(
+        embed = discord.Embed(
             title="Subreddits' statuses",
             description="\n".join([s.status for s in subreddits]),
             colour=embed_color or subreddits[0].banhammer.embed_color if subreddits else BANHAMMER_PURPLE
         )
+        embed.timestamp = datetime.utcnow()
+        return

--- a/banhammer/models/subreddit.py
+++ b/banhammer/models/subreddit.py
@@ -70,7 +70,8 @@ class Subreddit:
 
         return str
 
-    def get_contact_url(self):
+    @property
+    def contact_url(self):
         return "https://www.reddit.com/message/compose/?to=/r/" + self.name
 
     async def get_subreddit(self):

--- a/banhammer/models/subreddit.py
+++ b/banhammer/models/subreddit.py
@@ -108,6 +108,9 @@ class Subreddit:
                 except Exception as e:
                     logger.error(f"Couldn't create wikipage: {e}")
 
+    async def get_reactions_embed(self, embed_color: discord.Color = None):
+        return await self.banhammer.message_builder.get_subreddit_reactions_embed(self, embed_color)
+
     def get_reactions(self, item: RedditItem):
         return [r for r in self.reactions if r.eligible(item)]
 

--- a/banhammer/models/subreddit.py
+++ b/banhammer/models/subreddit.py
@@ -108,8 +108,8 @@ class Subreddit:
                 except Exception as e:
                     logger.error(f"Couldn't create wikipage: {e}")
 
-    async def get_reactions_embed(self, embed_color: discord.Color = None):
-        return await self.banhammer.message_builder.get_subreddit_reactions_embed(self, embed_color)
+    async def get_reactions_embed(self, *args, **kwargs):
+        return await self.banhammer.message_builder.get_subreddit_reactions_embed(self, *args, **kwargs)
 
     def get_reactions(self, item: RedditItem):
         return [r for r in self.reactions if r.eligible(item)]

--- a/tests/models/test_subreddit.py
+++ b/tests/models/test_subreddit.py
@@ -13,7 +13,7 @@ class TestSubreddit:
 
     @pytest.mark.asyncio
     async def test_contact_url(self, subreddit: Subreddit):
-        url = subreddit.get_contact_url()
+        url = subreddit.contact_url
         assert url == "https://www.reddit.com/message/compose/?to=/r/banhammerdemo"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #40 

 - Add `MessageBuilder.get_subreddit_reactions_embed()` to retrieve an embed for a single subreddit's configured reactions with a detailed breakdown.
   * Add `Subreddit.get_reactions_embed()` extension.
 - Fix usage of `discord.Color` in `const.py`.
 - Make `Subreddit.contact_url` auto-property instead of `get_contact_url()` method.