### PR TITLE
Embed Template Argument in MessageBuilder Methods, Usage of *args and **kwargs

### DIFF
--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -386,7 +386,7 @@ class Banhammer:
         s = str(c) if not isinstance(c, discord.Embed) else json.dumps(c.to_dict())
         return await reddit_helper.get_item(self.reddit, self.subreddits, s)
 
-    def get_reactions_embed(self, embed_color: discord.Color = None):
+    def get_reactions_embed(self, *args, **kwargs):
         """
         Load an embed with all the configured reactions per subreddit.
 
@@ -401,9 +401,9 @@ class Banhammer:
         embed: discord.Embed
             The embed listing all the configured reactions per subreddit.
         """
-        return self.message_builder.get_reactions_embed(self.subreddits)
+        return self.message_builder.get_reactions_embed(self.subreddits, *args, **kwargs)
 
-    def get_subreddits_embed(self, embed_color: discord.Color = None):
+    def get_subreddits_embed(self, *args, **kwargs):
         """
         Load an embed with all the configured subreddits and their enabled streams.
 
@@ -418,7 +418,7 @@ class Banhammer:
         embed: discord.Embed
             The embed of all the subreddits and their enabled streams.
         """
-        return self.message_builder.get_subreddits_embed(self.subreddits)
+        return self.message_builder.get_subreddits_embed(self.subreddits, *args, **kwargs)
 
     def run(self):
         """

--- a/banhammer/models/item.py
+++ b/banhammer/models/item.py
@@ -31,8 +31,8 @@ class RedditItem:
     async def get_message(self):
         return await self.subreddit.banhammer.message_builder.get_item_message(self)
 
-    async def get_embed(self, embed_color: discord.Color = None):
-        return await self.subreddit.banhammer.message_builder.get_item_embed(self, embed_color)
+    async def get_embed(self, *args, **kwargs):
+        return await self.subreddit.banhammer.message_builder.get_item_embed(self, *args, **kwargs)
 
     def format_reply(self, reply: str):
         return self.subreddit.banhammer.message_builder.format_reply(self, reply)

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -139,7 +139,7 @@ class MessageBuilder:
         if not payload.actions:
             payload.actions.append("dismissed")
 
-        embed = discord.Embed(
+        embed = embed_template or discord.Embed(
             colour=embed_color or payload.item.subreddit.banhammer.embed_color
         )
 

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -143,10 +143,10 @@ class MessageBuilder:
             colour=embed_color or payload.item.subreddit.banhammer.embed_color
         )
 
+        author_name = escape_markdown(await payload.item.get_author_name())
+
         embed.description = f"[{payload.item.type.title()}]({payload.item.url}) by /u/{author_name}."
         embed.timestamp = datetime.utcnow()
-
-        author_name = escape_markdown(await payload.item.get_author_name())
 
         embed.set_author(name=f"{payload.item.type.title()} {' and '.join(payload.actions)} by {payload.user}!")
 

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -31,8 +31,9 @@ class MessageBuilder:
             subreddit = escape_markdown(str(item.subreddit))
             return f"New action taken by /u/{author_name} on /r/{subreddit}: `{item.body}`"
 
-    async def get_item_embed(self, item: RedditItem, embed_color: discord.Color = None):
-        embed = discord.Embed(
+    async def get_item_embed(self, item: RedditItem, embed_color: discord.Color = None,
+                             embed_template: discord.Embed = None):
+        embed = embed_template or discord.Embed(
             colour=embed_color or item.subreddit.banhammer.embed_color
         )
 
@@ -133,15 +134,16 @@ class MessageBuilder:
         return f"**{payload.item.type.title()} {' and '.join(payload.actions)} by {user}!**\n\n" \
                f"{payload.item.type.title()} by /u/{author_name}:\n\n{url}"
 
-    async def get_payload_embed(self, payload: ReactionPayload, embed_color: discord.Color = None):
+    async def get_payload_embed(self, payload: ReactionPayload, embed_color: discord.Color = None,
+                                embed_template: discord.Embed = None):
         if not payload.actions:
             payload.actions.append("dismissed")
 
         embed = discord.Embed(
-            description=f"[{payload.item.type.title()}]({payload.item.url}) by /u/{author_name}.",
             colour=embed_color or payload.item.subreddit.banhammer.embed_color
         )
 
+        embed.description = f"[{payload.item.type.title()}]({payload.item.url}) by /u/{author_name}."
         embed.timestamp = datetime.utcnow()
 
         author_name = escape_markdown(await payload.item.get_author_name())
@@ -150,7 +152,8 @@ class MessageBuilder:
 
         return embed
 
-    def get_reactions_embed(self, subreddits: List[Subreddit], embed_color: discord.Color = None):
+    def get_reactions_embed(self, subreddits: List[Subreddit], embed_color: discord.Color = None,
+                            embed_template: discord.Embed = None):
         """
         Load an embed with all the configured reactions per subreddit.
 
@@ -167,11 +170,11 @@ class MessageBuilder:
         embed: discord.Embed
             The embed listing all the configured reactions per subreddit.
         """
-        embed = discord.Embed(
-            title="Configured reactions",
+        embed = embed_template or discord.Embed(
             colour=embed_color or subreddits[0].banhammer.embed_color if subreddits else BANHAMMER_PURPLE
         )
 
+        embed.title = "Configured reactions"
         embed.timestamp = datetime.utcnow()
 
         for sub in subreddits:
@@ -180,7 +183,8 @@ class MessageBuilder:
                             inline=False)
         return embed
 
-    def get_subreddits_embed(self, subreddits: List[Subreddit], embed_color: discord.Color = None):
+    def get_subreddits_embed(self, subreddits: List[Subreddit], embed_color: discord.Color = None,
+                             embed_template: discord.Embed = None):
         """
         Load an embed with all the configured subreddits and their enabled streams.
 
@@ -197,16 +201,19 @@ class MessageBuilder:
         embed: discord.Embed
             The embed of all the subreddits and their enabled streams.
         """
-        embed = discord.Embed(
-            title="Subreddits' statuses",
-            description="\n".join([s.status for s in subreddits]),
+        embed = embed_template or discord.Embed(
             colour=embed_color or subreddits[0].banhammer.embed_color if subreddits else BANHAMMER_PURPLE
         )
+
+        embed.title = "Subreddits' statuses"
+        embed.description = "\n".join([s.status for s in subreddits])
         embed.timestamp = datetime.utcnow()
+
         return embed
 
-    async def get_subreddit_reactions_embed(self, subreddit: Subreddit, embed_color: discord.Color = None):
-        embed = discord.Embed(
+    async def get_subreddit_reactions_embed(self, subreddit: Subreddit, embed_color: discord.Color = None,
+                                            embed_template: discord.Embed = None):
+        embed = embed_template or discord.Embed(
             colour=embed_color or subreddit.banhammer.embed_color
         )
 

--- a/banhammer/models/reaction.py
+++ b/banhammer/models/reaction.py
@@ -30,8 +30,8 @@ class ReactionPayload:
     async def get_message(self):
         return await self.item.subreddit.banhammer.message_builder.get_payload_message(self)
 
-    async def get_embed(self):
-        return await self.item.subreddit.banhammer.message_builder.get_payload_embed(self)
+    async def get_embed(self, *args, **kwargs):
+        return await self.item.subreddit.banhammer.message_builder.get_payload_embed(self, *args, **kwargs)
 
     def __repr__(self):
         return f"<ReactionPayload item={self.item} approved={self.approved} actions={self.actions}>"


### PR DESCRIPTION
Closes #37 

 - Add `embed_template` argument to all `class MessageBuilder` methods that build embeds, and override necessary fields manually.
 - Extension methods calling MessageBuilder methods use *args and **kwargs for easier modifications to method signatures in the future.