### PR TITLE
Reaction Schemas and Reaction.copy()

### DIFF
--- a/banhammer/models/reaction.py
+++ b/banhammer/models/reaction.py
@@ -157,7 +157,7 @@ class Reaction:
         self._schema = {**self.SCHEMA, **(schema or {})}
 
         self._data = {**self._schema, **kwargs}
-        self._data["emoji"] = self._data["emoji"]["emoji"].strip()
+        self._data["emoji"] = self._data["emoji"].strip()
         self._data["distinguish_reply"] = self._data["distinguish_reply"] or self._data["sticky_reply"]
 
         for k, v in self._data.items():

--- a/banhammer/models/reaction.py
+++ b/banhammer/models/reaction.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 
 import discord
 from apraw.models import (Comment, ModmailConversation, ModmailMessage,
@@ -164,7 +164,7 @@ class Reaction:
             if not hasattr(self, k):
                 setattr(self, k, v)
 
-    def copy(self) -> Reaction:
+    def copy(self) -> 'Reaction':
         return type(self)(self._schema, **self._data)
 
     def __str__(self):

--- a/banhammer/models/reaction.py
+++ b/banhammer/models/reaction.py
@@ -138,31 +138,34 @@ class ReactionHandler:
 
 class Reaction:
 
-    def __init__(self, **kwargs):
-        self.config = kwargs
+    SCHEMA = {
+        "type": "",
+        "flair": "",
+        "approve": False,
+        "mark_nsfw": False,
+        "lock": False,
+        "reply": "",
+        "sticky_reply": True,
+        "distinguish_reply": True,
+        "ban": None,
+        "archive": False,
+        "mute": False,
+        "min_votes": 1
+    }
 
-        self.emoji = kwargs["emoji"].strip()
+    def __init__(self, schema: Dict = None, **kwargs):
+        self._schema = {**self.SCHEMA, **(schema or {})}
 
-        data = {
-            "type": "",
-            "flair": "",
-            "approve": False,
-            "mark_nsfw": False,
-            "lock": False,
-            "reply": "",
-            "sticky_reply": True,
-            "distinguish_reply": True,
-            "ban": None,
-            "archive": False,
-            "mute": False,
-            "min_votes": 1,
-            **kwargs
-        }
+        self._data = {**self._schema, **kwargs}
+        self._data["emoji"] = self._data["emoji"]["emoji"].strip()
+        self._data["distinguish_reply"] = self._data["distinguish_reply"] or self._data["sticky_reply"]
 
-        data["distinguish_reply"] = data["distinguish_reply"] or data["sticky_reply"]
+        for k, v in self._data.items():
+            if not hasattr(self, k):
+                setattr(self, k, v)
 
-        for k, v in data.items():
-            setattr(self, k, v)
+    def copy(self) -> Reaction:
+        return type(self)(self._schema, **self._data)
 
     def __str__(self):
         return self.emoji
@@ -205,10 +208,10 @@ class Reaction:
 
     def eligible(self, item: Union[Submission, Comment, ModmailMessage, ModmailConversation]):
         if isinstance(item, Submission):
-            if self.type == "" or self.type == "submission":
+            if not self.type or self.type == "submission":
                 return True
         elif isinstance(item, Comment):
-            if self.type == "" or self.type == "comment":
+            if not self.type or self.type == "comment":
                 return True
         elif isinstance(item, (ModmailMessage, ModmailConversation)):
             if self.type == "mail":

--- a/tests/models/test_reaction.py
+++ b/tests/models/test_reaction.py
@@ -43,7 +43,10 @@ class TestReaction:
     async def test_copy(self, subreddit: Subreddit):
         await subreddit.load_reactions()
 
-        new = subreddit.reactions[0].copy()
+        old = subreddit.reactions[0]
+        new = old.copy()
+
+        assert isinstance(new, type(old))
 
         for key in new.SCHEMA:
-            assert getattr(new, key) == getattr(subreddit.reactions[0], key)
+            assert getattr(new, key) == getattr(old, key)

--- a/tests/models/test_reaction.py
+++ b/tests/models/test_reaction.py
@@ -1,7 +1,7 @@
 import apraw
 import pytest
 
-from banhammer.models import RedditItem, Subreddit, ReactionPayload
+from banhammer.models import ReactionPayload, RedditItem, Subreddit
 
 
 class TestReactionPayload:
@@ -36,3 +36,14 @@ class TestReactionPayload:
         payload.feed(item, False, "Test", "🔥", "Test reply.")
 
         assert isinstance(await payload.get_message(), str)
+
+
+class TestReaction:
+    @pytest.mark.asyncio
+    async def test_copy(self, subreddit: Subreddit):
+        await subreddit.load_reactions()
+
+        new = subreddit.reactions[0].copy()
+
+        for key in new.SCHEMA:
+            assert getattr(new, key) == getattr(subreddit.reactions[0], key)


### PR DESCRIPTION
Closes #34 

 - Add `schema` argument to `class Reaction` constructor.
 - Add `Reaction.SCHEMA` default schema.
 - Add `Reaction.copy()` returning new reaction with identical data.