### PR TITLE
BanhammerMeta Metaclass and Upgraded Event-Handling

### DIFF
--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -430,8 +430,13 @@ class Banhammer(metaclass=BanhammerMeta):
 
             funcs = set()
 
-            for handler in self._event_handlers:
-                funcs.update((func, handler._identifier) for func in handler.get_sub_funcs(self.subreddits))
+            if self._event_handlers:
+                for handler in self._event_handlers:
+                    funcs.update((func, handler._identifier) for func in handler.get_sub_funcs(self.subreddits))
+            else:
+                for subreddit in self.subreddits:
+                    funcs.update((getattr(subreddit, f"get_{identifier}"), identifier)
+                                 for identifier in GeneratorIdentifier)
 
             found = False
             for func in funcs:

--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -374,9 +374,10 @@ class Banhammer(metaclass=BanhammerMeta):
             The subreddit to poll with this function.
         """
         event_filter = EventFilter(ItemAttribute.MOD, *kwargs.get("mods", tuple()), *args)
+        create_args = tuple()
         if event_filter._values:
-            args = (event_filter)
-        return self.add_event_handler(func, GeneratorIdentifier.MOD_ACTIONS, *args, **kwargs)
+            create_args = (*create_args, event_filter)
+        return self.add_event_handler(func, GeneratorIdentifier.MOD_ACTIONS, *create_args, **kwargs)
 
     async def handle_mod_actions(self, item: RedditItem):
         """

--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -161,7 +161,7 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            handler_args = (self, *handler_args) if handler._takes_self else (item,)
+            handler_args = (self, item) if handler._takes_self else (item,)
             await handler(GeneratorIdentifier.NEW, *handler_args)
 
     def comments(self, **kwargs):
@@ -207,7 +207,7 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            handler_args = (self, *handler_args) if handler._takes_self else (item,)
+            handler_args = (self, item) if handler._takes_self else (item,)
             await handler(GeneratorIdentifier.COMMENTS, *handler_args)
 
     def mail(self, **kwargs):
@@ -253,7 +253,7 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            handler_args = (self, *handler_args) if handler._takes_self else (item,)
+            handler_args = (self, item) if handler._takes_self else (item,)
             await handler(GeneratorIdentifier.MAIL, *handler_args)
 
     def queue(self, **kwargs):
@@ -299,7 +299,7 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            handler_args = (self, *handler_args) if handler._takes_self else (item,)
+            handler_args = (self, item) if handler._takes_self else (item,)
             await handler(GeneratorIdentifier.QUEUE, *handler_args)
 
     def reports(self, **kwargs):
@@ -345,7 +345,7 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            handler_args = (self, *handler_args) if handler._takes_self else (item,)
+            handler_args = (self, item) if handler._takes_self else (item,)
             await handler(GeneratorIdentifier.REPORTS, *handler_args)
 
     def mod_actions(self, *args, **kwargs):
@@ -396,7 +396,7 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            handler_args = (self, *handler_args) if handler._takes_self else (item,)
+            handler_args = (self, item) if handler._takes_self else (item,)
             await handler(GeneratorIdentifier.MOD_ACTIONS, *handler_args)
 
     def add_event_handler(self, func: Callable[[RedditItem], Awaitable[None]],

--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -373,11 +373,10 @@ class Banhammer(metaclass=BanhammerMeta):
         subreddit : str or Subreddit
             The subreddit to poll with this function.
         """
-        return self.add_event_handler(
-            func,
-            GeneratorIdentifier.MOD_ACTIONS,
-            EventFilter(ItemAttribute.MOD, *kwargs.get("mods", tuple()), *args),
-            **kwargs)
+        event_filter = EventFilter(ItemAttribute.MOD, *kwargs.get("mods", tuple()), *args)
+        if event_filter._values:
+            args = (event_filter)
+        return self.add_event_handler(func, GeneratorIdentifier.MOD_ACTIONS, *args, **kwargs)
 
     async def handle_mod_actions(self, item: RedditItem):
         """

--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -161,7 +161,10 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            await handler(self, item) if handler._takes_self else await handler(item)
+            handler_args = (GeneratorIdentifier.NEW, item)
+            if handler._takes_self:
+                handler_args = (self, *handler_args)
+            await handler(*handler_args)
 
     def comments(self, **kwargs):
         """
@@ -206,7 +209,10 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            await handler(self, item) if handler._takes_self else await handler(item)
+            handler_args = (GeneratorIdentifier.COMMENTS, item)
+            if handler._takes_self:
+                handler_args = (self, *handler_args)
+            await handler(*handler_args)
 
     def mail(self, **kwargs):
         """
@@ -251,7 +257,10 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            await handler(self, item) if handler._takes_self else await handler(item)
+            handler_args = (GeneratorIdentifier.MAIL, item)
+            if handler._takes_self:
+                handler_args = (self, *handler_args)
+            await handler(*handler_args)
 
     def queue(self, **kwargs):
         """
@@ -296,7 +305,10 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            await handler(self, item) if handler._takes_self else await handler(item)
+            handler_args = (GeneratorIdentifier.QUEUE, item)
+            if handler._takes_self:
+                handler_args = (self, *handler_args)
+            await handler(*handler_args)
 
     def reports(self, **kwargs):
         """
@@ -341,7 +353,10 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            await handler(self, item) if handler._takes_self else await handler(item)
+            handler_args = (GeneratorIdentifier.REPORTS, item)
+            if handler._takes_self:
+                handler_args = (self, *handler_args)
+            await handler(*handler_args)
 
     def mod_actions(self, *args, **kwargs):
         """
@@ -393,7 +408,10 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            await handler(self, item) if handler._takes_self else await handler(item)
+            handler_args = (GeneratorIdentifier.MOD_ACTIONS, item)
+            if handler._takes_self:
+                handler_args = (self, *handler_args)
+            await handler(*handler_args)
 
     def add_event_handler(self, func: Callable[[RedditItem], Awaitable[None]],
                           identifier: GeneratorIdentifier, *args, **kwargs):

--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -508,5 +508,4 @@ class Banhammer:
             print(re.sub(r"\*\*(.+)\*\*", r"{}\1{}".format(BOLD, END), f.read()))
             print("")
 
-        if self._event_handlers:
-            self._loop.create_task(self.send_items())
+        self._loop.create_task(self.send_items())

--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -130,11 +130,9 @@ class Banhammer(metaclass=BanhammerMeta):
             async def handle_new(item: RedditItem):
                 pass
         """
-        def assign(func: Callable[[RedditItem], Awaitable[None]]):
-            self.add_new_handler(func, **kwargs)
-            return func
-
-        return assign
+        def wrapper(func: Callable[[RedditItem], Awaitable[None]]):
+            return self.add_new_handler(func, **kwargs)
+        return wrapper
 
     def add_new_handler(self, func: Callable[[RedditItem], Awaitable[None]], **kwargs):
         """
@@ -147,7 +145,7 @@ class Banhammer(metaclass=BanhammerMeta):
         subreddit : str or Subreddit
             The subreddit to poll with this function.
         """
-        self.add_event_handler(func, GeneratorIdentifier.NEW, **kwargs)
+        return self.add_event_handler(func, GeneratorIdentifier.NEW, **kwargs)
 
     async def handle_new(self, item: RedditItem):
         """

--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -177,11 +177,9 @@ class Banhammer(metaclass=BanhammerMeta):
             async def handle_comments(item: RedditItem):
                 pass
         """
-        def assign(func: Callable[[RedditItem], Awaitable[None]]):
-            self.add_comments_handler(func, **kwargs)
-            return func
-
-        return assign
+        def wrapper(func: Callable[[RedditItem], Awaitable[None]]):
+            return self.add_comments_handler(func, **kwargs)
+        return wrapper
 
     def add_comments_handler(self, func: Callable[[RedditItem], Awaitable[None]], **kwargs):
         """
@@ -194,7 +192,7 @@ class Banhammer(metaclass=BanhammerMeta):
         subreddit : str or Subreddit
             The subreddit to poll with this function.
         """
-        self.add_event_handler(func, GeneratorIdentifier.COMMENTS, **kwargs)
+        return self.add_event_handler(func, GeneratorIdentifier.COMMENTS, **kwargs)
 
     async def handle_comments(self, item: RedditItem):
         """
@@ -224,11 +222,9 @@ class Banhammer(metaclass=BanhammerMeta):
             async def handle_mail(item: RedditItem):
                 pass
         """
-        def assign(func: Callable[[RedditItem], Awaitable[None]]):
-            self.add_mail_handler(func, **kwargs)
-            return func
-
-        return assign
+        def wrapper(func: Callable[[RedditItem], Awaitable[None]]):
+            return self.add_mail_handler(func, **kwargs)
+        return wrapper
 
     def add_mail_handler(self, func: Callable[[RedditItem], Awaitable[None]], **kwargs):
         """
@@ -241,7 +237,7 @@ class Banhammer(metaclass=BanhammerMeta):
         subreddit : str or Subreddit
             The subreddit to poll with this function.
         """
-        self.add_event_handler(func, GeneratorIdentifier.MAIL, **kwargs)
+        return self.add_event_handler(func, GeneratorIdentifier.MAIL, **kwargs)
 
     async def handle_mail(self, item: RedditItem):
         """
@@ -271,11 +267,9 @@ class Banhammer(metaclass=BanhammerMeta):
             async def handle_queue(item: RedditItem):
                 pass
         """
-        def assign(func: Callable[[RedditItem], Awaitable[None]]):
-            self.add_queue_handler(func, **kwargs)
-            return func
-
-        return assign
+        def wrapper(func: Callable[[RedditItem], Awaitable[None]]):
+            return self.add_queue_handler(func, **kwargs)
+        return wrapper
 
     def add_queue_handler(self, func: Callable[[RedditItem], Awaitable[None]], **kwargs):
         """
@@ -288,7 +282,7 @@ class Banhammer(metaclass=BanhammerMeta):
         subreddit : str or Subreddit
             The subreddit to poll with this function.
         """
-        self.add_event_handler(func, GeneratorIdentifier.QUEUE, **kwargs)
+        return self.add_event_handler(func, GeneratorIdentifier.QUEUE, **kwargs)
 
     async def handle_queue(self, item: RedditItem):
         """
@@ -318,11 +312,9 @@ class Banhammer(metaclass=BanhammerMeta):
             async def handle_reports(item: RedditItem):
                 pass
         """
-        def assign(func: Callable[[RedditItem], Awaitable[None]]):
-            self.add_reports_handler(func, **kwargs)
-            return func
-
-        return assign
+        def wrapper(func: Callable[[RedditItem], Awaitable[None]]):
+            return self.add_reports_handler(func, **kwargs)
+        return wrapper
 
     def add_reports_handler(self, func: Callable[[RedditItem], Awaitable[None]], **kwargs):
         """
@@ -335,7 +327,7 @@ class Banhammer(metaclass=BanhammerMeta):
         subreddit : str or Subreddit
             The subreddit to poll with this function.
         """
-        self.add_event_handler(func, GeneratorIdentifier.REPORTS, **kwargs)
+        return self.add_event_handler(func, GeneratorIdentifier.REPORTS, **kwargs)
 
     async def handle_reports(self, item: RedditItem):
         """
@@ -366,11 +358,9 @@ class Banhammer(metaclass=BanhammerMeta):
             async def handle_mod_actions(item: RedditItem):
                 pass
         """
-        def assign(func: Callable[[RedditItem], Awaitable[None]]):
-            self.add_mod_actions_handler(func, *args, **kwargs)
-            return func
-
-        return assign
+        def wrapper(func: Callable[[RedditItem], Awaitable[None]]):
+            return self.add_mod_actions_handler(func, *args, **kwargs)
+        return wrapper
 
     def add_mod_actions_handler(self, func: Callable[[RedditItem], Awaitable[None]], *args, **kwargs):
         """
@@ -385,10 +375,10 @@ class Banhammer(metaclass=BanhammerMeta):
         subreddit : str or Subreddit
             The subreddit to poll with this function.
         """
-        self.add_event_handler(
+        return self.add_event_handler(
             func,
             GeneratorIdentifier.MOD_ACTIONS,
-            EventFilter(ItemAttribute.MOD, *(mod for mod in kwargs.get("mods", tuple())), *args),
+            EventFilter(ItemAttribute.MOD, *kwargs.get("mods", tuple()), *args),
             **kwargs)
 
     async def handle_mod_actions(self, item: RedditItem):
@@ -422,14 +412,9 @@ class Banhammer(metaclass=BanhammerMeta):
         subreddit : str or Subreddit
             The subreddit to poll with this function.
         """
-        if asyncio.iscoroutinefunction(func):
-            if kwargs.get("subreddit", None):
-                if isinstance(kwargs["subreddit"], (str, apraw.models.Subreddit, Subreddit)):
-                    args = (*args, EventFilter(ItemAttribute.SUBREDDIT, str(kwargs["subreddit"])))
-                else:
-                    args = (*args, EventFilter(ItemAttribute.SUBREDDIT, *(sub for sub in kwargs["subreddit"])))
-
-            self._event_handlers.append(EventHandler(func, identifier, *args))
+        event_handler = EventHandler.create_event_handler(func, identifier, *args, **kwargs)
+        self._event_handlers.append(event_handler)
+        return event_handler
 
     async def send_items(self):
         """

--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -163,7 +163,7 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            await handler(item, GeneratorIdentifier.NEW)
+            await handler(self, item) if handler._takes_self else await handler(item)
 
     def comments(self, **kwargs):
         """
@@ -208,7 +208,7 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            await handler(item, GeneratorIdentifier.COMMENTS)
+            await handler(self, item) if handler._takes_self else await handler(item)
 
     def mail(self, **kwargs):
         """
@@ -253,7 +253,7 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            await handler(item, GeneratorIdentifier.MAIL)
+            await handler(self, item) if handler._takes_self else await handler(item)
 
     def queue(self, **kwargs):
         """
@@ -298,7 +298,7 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            await handler(item, GeneratorIdentifier.QUEUE)
+            await handler(self, item) if handler._takes_self else await handler(item)
 
     def reports(self, **kwargs):
         """
@@ -343,7 +343,7 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            await handler(item, GeneratorIdentifier.REPORTS)
+            await handler(self, item) if handler._takes_self else await handler(item)
 
     def mod_actions(self, *args, **kwargs):
         """
@@ -395,7 +395,7 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            await handler(item, GeneratorIdentifier.MOD_ACTIONS)
+            await handler(self, item) if handler._takes_self else await handler(item)
 
     def add_event_handler(self, func: Callable[[RedditItem], Awaitable[None]],
                           identifier: GeneratorIdentifier, *args, **kwargs):

--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -422,7 +422,7 @@ class Banhammer:
 
     def run(self):
         """
-        Start the banhammer poll loop.
+        Add the Banhammer poll loop to the ``asyncio`` event loop.
         """
         path = os.path.abspath(os.path.join(os.path.dirname(__file__), "WELCOME.md"))
         with open(path) as f:

--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -389,9 +389,7 @@ class Banhammer(metaclass=BanhammerMeta):
             The subreddit to poll with this function.
         """
         event_filter = EventFilter(ItemAttribute.MOD, *kwargs.get("mods", tuple()), *args)
-        create_args = tuple()
-        if event_filter._values:
-            create_args = (*create_args, event_filter)
+        create_args = (event_filter,) if event_filter._values else tuple()
         return self.add_event_handler(func, GeneratorIdentifier.MOD_ACTIONS, *create_args, **kwargs)
 
     async def handle_mod_actions(self, item: RedditItem):

--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -161,10 +161,8 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            handler_args = (GeneratorIdentifier.NEW, item)
-            if handler._takes_self:
-                handler_args = (self, *handler_args)
-            await handler(*handler_args)
+            handler_args = (self, *handler_args) if handler._takes_self else (item,)
+            await handler(GeneratorIdentifier.NEW, *handler_args)
 
     def comments(self, **kwargs):
         """
@@ -209,10 +207,8 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            handler_args = (GeneratorIdentifier.COMMENTS, item)
-            if handler._takes_self:
-                handler_args = (self, *handler_args)
-            await handler(*handler_args)
+            handler_args = (self, *handler_args) if handler._takes_self else (item,)
+            await handler(GeneratorIdentifier.COMMENTS, *handler_args)
 
     def mail(self, **kwargs):
         """
@@ -257,10 +253,8 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            handler_args = (GeneratorIdentifier.MAIL, item)
-            if handler._takes_self:
-                handler_args = (self, *handler_args)
-            await handler(*handler_args)
+            handler_args = (self, *handler_args) if handler._takes_self else (item,)
+            await handler(GeneratorIdentifier.MAIL, *handler_args)
 
     def queue(self, **kwargs):
         """
@@ -305,10 +299,8 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            handler_args = (GeneratorIdentifier.QUEUE, item)
-            if handler._takes_self:
-                handler_args = (self, *handler_args)
-            await handler(*handler_args)
+            handler_args = (self, *handler_args) if handler._takes_self else (item,)
+            await handler(GeneratorIdentifier.QUEUE, *handler_args)
 
     def reports(self, **kwargs):
         """
@@ -353,10 +345,8 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            handler_args = (GeneratorIdentifier.REPORTS, item)
-            if handler._takes_self:
-                handler_args = (self, *handler_args)
-            await handler(*handler_args)
+            handler_args = (self, *handler_args) if handler._takes_self else (item,)
+            await handler(GeneratorIdentifier.REPORTS, *handler_args)
 
     def mod_actions(self, *args, **kwargs):
         """
@@ -406,10 +396,8 @@ class Banhammer(metaclass=BanhammerMeta):
             The item to forward to handlers.
         """
         for handler in self._event_handlers:
-            handler_args = (GeneratorIdentifier.MOD_ACTIONS, item)
-            if handler._takes_self:
-                handler_args = (self, *handler_args)
-            await handler(*handler_args)
+            handler_args = (self, *handler_args) if handler._takes_self else (item,)
+            await handler(GeneratorIdentifier.MOD_ACTIONS, *handler_args)
 
     def add_event_handler(self, func: Callable[[RedditItem], Awaitable[None]],
                           identifier: GeneratorIdentifier, *args, **kwargs):

--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -496,7 +496,7 @@ class Banhammer:
         """
         return self.message_builder.get_subreddits_embed(self.subreddits, *args, **kwargs)
 
-    def run(self):
+    def start(self):
         """
         Add the Banhammer poll loop to the ``asyncio`` event loop.
         """

--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -446,7 +446,7 @@ class Banhammer(metaclass=BanhammerMeta):
 
             if self._event_handlers:
                 for handler in self._event_handlers:
-                    funcs.update((func, handler._identifier) for func in handler.get_sub_funcs(self.subreddits))
+                    funcs.update(func for func in handler.get_sub_funcs(self.subreddits))
             else:
                 for subreddit in self.subreddits:
                     funcs.update((getattr(subreddit, f"get_{identifier}"), identifier)

--- a/banhammer/models/__init__.py
+++ b/banhammer/models/__init__.py
@@ -1,3 +1,5 @@
+from .event_handler import (EventFilter, EventHandler, GeneratorIdentifier,
+                            ItemAttribute)
 from .item import RedditItem
 from .message_builder import MessageBuilder
 from .reaction import (Reaction, ReactionHandler, ReactionPayload,

--- a/banhammer/models/event_handler.py
+++ b/banhammer/models/event_handler.py
@@ -104,9 +104,7 @@ class EventHandler:
     def mod_actions(cls, *args, **kwargs):
         def wrapper(func: Callable[['RedditItem'], Awaitable[None]]):
             event_filter = EventFilter(ItemAttribute.MOD, *kwargs.get("mods", tuple()), *args)
-            create_args = tuple()
-            if event_filter._values:
-                create_args = (*create_args, event_filter)
+            create_args = (event_filter,) if event_filter._values else tuple()
             return cls.create_event_handler(func, GeneratorIdentifier.MOD_ACTIONS, *create_args, **kwargs)
         return wrapper
 

--- a/banhammer/models/event_handler.py
+++ b/banhammer/models/event_handler.py
@@ -125,7 +125,7 @@ class EventHandler:
             handler = EventHandler(handler, identifier, *args)
         else:
             handler._identifiers.add(identifier)
-            handler._filters.extend(*args)
+            handler._filters.extend(args)
 
         return handler
 
@@ -141,7 +141,7 @@ class EventHandler:
         return wrapper
 
     async def __call__(self, identifier: GeneratorIdentifier, *args):
-        valid = identifier in self._identifiers
+        valid = identifier not in self._identifiers
 
         if not valid:
             return

--- a/banhammer/models/event_handler.py
+++ b/banhammer/models/event_handler.py
@@ -97,14 +97,16 @@ class EventHandler:
     @classmethod
     def reports(cls, **kwargs):
         def wrapper(func: Callable[['RedditItem'], Awaitable[None]]):
-            return cls.create_event_handler(func, GeneratorIdentifier.REPORTS, GeneratorIdentifier.REPORTS, **kwargs)
+            return cls.create_event_handler(func, GeneratorIdentifier.REPORTS, **kwargs)
         return wrapper
 
     @classmethod
     def mod_actions(cls, *args, **kwargs):
         def wrapper(func: Callable[['RedditItem'], Awaitable[None]]):
             event_filter = EventFilter(ItemAttribute.MOD, *kwargs.get("mods", tuple()), *args)
-            return cls.create_event_handler(func, GeneratorIdentifier.MOD_ACTIONS, event_filter, **kwargs)
+            if event_filter._values:
+                args = (event_filter)
+            return cls.create_event_handler(func, GeneratorIdentifier.MOD_ACTIONS, *args, **kwargs)
         return wrapper
 
     @classmethod

--- a/banhammer/models/event_handler.py
+++ b/banhammer/models/event_handler.py
@@ -152,4 +152,5 @@ class EventHandler:
     def get_sub_funcs(self, subreddits: List['Subreddit']):
         for subreddit in subreddits:
             if all(f.is_subreddit_valid(subreddit) for f in self._filters):
-                yield getattr(subreddit, f"get_{self._identifier}")
+                for identifier in self._identifiers:
+                    yield getattr(subreddit, f"get_{identifier}"), identifier

--- a/banhammer/models/event_handler.py
+++ b/banhammer/models/event_handler.py
@@ -59,7 +59,8 @@ class EventFilter:
         return True
 
     def is_subreddit_valid(self, subreddit: 'Subreddit'):
-        return any(str(subreddit).lower() == str(v).lower() for v in self._values) or not self._values
+        return self._attribute != ItemAttribute.SUBREDDIT or any(
+            str(subreddit).lower() == str(v).lower() for v in self._values) or not self._values
 
 
 class EventHandler:
@@ -156,6 +157,6 @@ class EventHandler:
 
     def get_sub_funcs(self, subreddits: List['Subreddit']):
         for subreddit in subreddits:
-            if all(f.is_subreddit_valid(subreddit) for f in self._filters):
+            if all(f.is_subreddit_valid(subreddit) for f in self._filters if f._attribute == ItemAttribute.SUBREDDIT):
                 for identifier in self._identifiers:
                     yield getattr(subreddit, f"get_{identifier}"), identifier

--- a/banhammer/models/event_handler.py
+++ b/banhammer/models/event_handler.py
@@ -104,9 +104,10 @@ class EventHandler:
     def mod_actions(cls, *args, **kwargs):
         def wrapper(func: Callable[['RedditItem'], Awaitable[None]]):
             event_filter = EventFilter(ItemAttribute.MOD, *kwargs.get("mods", tuple()), *args)
+            create_args = tuple()
             if event_filter._values:
-                args = (event_filter)
-            return cls.create_event_handler(func, GeneratorIdentifier.MOD_ACTIONS, *args, **kwargs)
+                create_args = (*create_args, event_filter)
+            return cls.create_event_handler(func, GeneratorIdentifier.MOD_ACTIONS, *create_args, **kwargs)
         return wrapper
 
     @classmethod

--- a/banhammer/models/event_handler.py
+++ b/banhammer/models/event_handler.py
@@ -1,0 +1,83 @@
+import enum
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, List
+
+if TYPE_CHECKING:
+    from .item import RedditItem
+    from .subreddit import Subreddit
+
+
+class ItemAttribute(enum.Enum):
+    SUBREDDIT = "subreddit"
+    AUTHOR = "author"
+    MOD = "mod"
+
+
+class GeneratorIdentifier(enum.Enum):
+    NEW = "new"
+    COMMENTS = "comments"
+    REPORTS = "reports"
+    MAIL = "mail"
+    QUEUE = "queue"
+    MOD_ACTIONS = "mod_actions"
+
+    def __str__(self):
+        return str(self.value)
+
+
+class EventFilter:
+
+    def __init__(self, attribute: ItemAttribute, *args, **kwargs):
+        self._attribute = attribute
+        self._values = args
+        self._reverse = kwargs.get("reverse", False)
+
+    async def is_item_valid(self, item: 'RedditItem'):
+        if self._attribute == ItemAttribute.MOD:
+            if item.type != "mod action":
+                return False
+            mod_name = await item.get_author_name()
+            if not any(mod_name.lower() == str(v).lower() for v in self._values):
+                return False
+            elif self._reverse:
+                return False
+        elif self._attribute == ItemAttribute.AUTHOR:
+            author_name = await item.get_author_name()
+            if not any(author_name.lower() == str(v).lower() for v in self._values):
+                return False
+            elif self._reverse:
+                return False
+        elif self._attribute == ItemAttribute.SUBREDDIT:
+            if not any(str(item.subreddit).lower() == str(v).lower() for v in self._values):
+                return False
+            elif self._reverse:
+                return False
+        return True
+
+    def is_subreddit_valid(self, subreddit: 'Subreddit'):
+        return any(str(subreddit).lower() == str(v).lower() for v in self._values) or not self._values
+
+
+class EventHandler:
+
+    def __init__(self, callback: Callable[['RedditItem'], Awaitable[None]], identifier: GeneratorIdentifier, *args):
+        self._callback = callback
+        self._identifier = identifier
+        self._filters = args
+
+    async def __call__(self, item: 'RedditItem', identifier: GeneratorIdentifier):
+        if identifier != self._identifier:
+            return
+
+        valid = True
+        for f in self._filters:
+            if not await f.is_item_valid(item):
+                valid = False
+                break
+
+        if valid:
+            await self._callback(item)
+
+    def get_sub_funcs(self, subreddits: List['Subreddit']):
+        for subreddit in subreddits:
+            if all(f.is_subreddit_valid(subreddit) for f in self._filters):
+                yield getattr(subreddit, f"get_{self._identifier}")

--- a/banhammer/models/event_handler.py
+++ b/banhammer/models/event_handler.py
@@ -141,7 +141,7 @@ class EventHandler:
         return wrapper
 
     async def __call__(self, identifier: GeneratorIdentifier, *args):
-        valid = identifier not in self._identifiers
+        valid = identifier in self._identifiers
 
         if not valid:
             return

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -42,7 +42,7 @@ class MessageBuilder:
         elif isinstance(item.item, ModmailMessage):
             embed.timestamp = datetime.utcfromtimestamp(item.item.conversation.last_updated)
         else:
-            embed.timestamp = item.item.created_utc
+            embed.timestamp = datetime.utcfromtimestamp(item.item._data["created_utc"])
 
         if item.type in ["submission", "comment"]:
             if item.source == "reports":

--- a/tests/test_banhammer.py
+++ b/tests/test_banhammer.py
@@ -9,18 +9,26 @@ class TestBanhammer:
     async def test_banhammer_meta(self):
         handle_new_called = 0
         handle_comments_called = 0
+        handle_mod_actions_called = 0
 
         class CustomBanhammer(Banhammer):
             @EventHandler.new()
             @EventHandler.filter(ItemAttribute.AUTHOR, "Dan6erbond")
             @EventHandler.filter(ItemAttribute.SUBREDDIT, "banhammerdemo")
-            async def some_name(self, item: RedditItem):
+            async def handle_new(self, item: RedditItem):
                 nonlocal handle_new_called
                 assert self, not item
                 handle_new_called += 1
 
+            @EventHandler.mod_actions("Anti-Evil Operations")
+            async def handle_mod_actions(self, item: RedditItem):
+                nonlocal handle_mod_actions_called
+                assert self, not item
+                handle_mod_actions_called += 1
+
         cb = CustomBanhammer(None)
         assert len(cb._event_handlers[0]._filters) == 2
+        assert len(cb._event_handlers[1]._filters[0]._values) == 1
 
         @cb.comments()
         async def handle_comments(item: RedditItem):
@@ -36,3 +44,4 @@ class TestBanhammer:
 
         assert handle_new_called == 1
         assert handle_comments_called == 1
+        assert handle_mod_actions_called == 1

--- a/tests/test_banhammer.py
+++ b/tests/test_banhammer.py
@@ -1,0 +1,38 @@
+import pytest
+
+from banhammer import Banhammer
+from banhammer.models import EventHandler, RedditItem, ItemAttribute
+
+
+class TestBanhammer:
+    @pytest.mark.asyncio
+    async def test_banhammer_meta(self):
+        handle_new_called = 0
+        handle_comments_called = 0
+
+        class CustomBanhammer(Banhammer):
+            @EventHandler.new()
+            @EventHandler.filter(ItemAttribute.AUTHOR, "Dan6erbond")
+            @EventHandler.filter(ItemAttribute.SUBREDDIT, "banhammerdemo")
+            async def some_name(self, item: RedditItem):
+                nonlocal handle_new_called
+                assert self, not item
+                handle_new_called += 1
+
+        cb = CustomBanhammer(None)
+        assert len(cb._event_handlers[0]._filters) == 2
+
+        @cb.comments()
+        async def handle_comments(item: RedditItem):
+            nonlocal handle_comments_called
+            assert not item
+            handle_comments_called += 1
+
+        for event_handler in cb._event_handlers:
+            if event_handler._takes_self:
+                await event_handler._callback(cb, None)
+            else:
+                await event_handler._callback(None)
+
+        assert handle_new_called == 1
+        assert handle_comments_called == 1


### PR DESCRIPTION
This update allows users to create a class-based Banhammer bot which can be integrated with the `commands.Bot` extension from Discord.py. Resulting in much cleaner code than standalone functions that cannot access internal properties and methods the way one might be used to. Such a bot could look as follows:

```py
class Banhacker(Bot, Banhammer):

    def __init__(self, **options):
        super().__init__(
            bh_config["command_prefix"],
            description="The Banhacker bot built for Discord's Hack-Week based on the Banhammer framework.",
            **options)
        Banhammer.__init__(self, reddit, bot=self, change_presence=bh_config["change_presence"])

    @property
    def embed(self):
        embed = discord.Embed(colour=self.embed_color)
        embed.set_footer(text=self.user.name, icon_url=self.user.avatar_url)
        embed.timestamp = datetime.now()
        return embed

    async def on_command_error(self, ctx: commands.Context, error):
        print(error)

    async def on_ready(self):
        print(str(self.user) + ' is running.')

        for sub in bh_config["subreddits"]:
            s = Subreddit(self, **sub)
            await s.load_reactions()
            await self.add_subreddits(s)

        Banhammer.start(self)

    @EventHandler.new()
    @EventHandler.comments()
    async def handle_new(self, p: RedditItem):
        msg = await self.get_channel(bh_config["new_channel"]).send(embed=await p.get_embed(embed_template=self.embed))
        await p.add_reactions(msg)

    @EventHandler.mod_actions()
    @EventHandler.filter(ItemAttribute.MOD, "Anti-Evil Operations", "Dan6erbond")
    async def handle_actions(self, p: RedditItem):
        msg = await self.get_channel(bh_config["actions_channel"]).send(embed=await p.get_embed(embed_template=self.embed))
        await p.add_reactions(msg)
```

**Note:** Bot using the old decorators such as `bot.new()` will continue to work, as this change only modifies the framework internally and enables the creation of classes inheriting from `class Banhammer`. Filters can be applied to the old-style callbacks simply by adding `@EventHandler.filter()` to the decorator list.

## Change Log

**Banhammer:**

 - Create `class BanhammerMeta` metaclass to move all `class EventHandler` registered callbacks to the internal handler list.
 - Calling registered event handlers with the internal `handle_{identifier}` methods, which fixes the loss of items when a queue is polled multiple times and ignores items.
 - Refactor `run()` to `start()` to be better aligned with Discord.py's naming conventions.
 - Refactor `class Banhammer` private members - this should not affect code using Banhammer.py.

**Note:** `Banhammer.start()` will always run the internal poll loop, regardless of registered events, and will poll all the endpoints if no event handlers are present. This allows users to manually override the `handle_{identifier}` methods.

**Event Handlers:**

 - Create `class EventHandler` to manage callbacks, expected identifier and filters.
   * Add `enum GeneratorIdentifier` to register handler methods.
   * Create decorators `EventHandler.new()`, `comments()`, `mail()`, `queue()`, `reports()` and `mod_actions()` to aid in converting functions/methods to `class EventHandler`.
 - Add `enum ItemAttribute` to aid in creating filters.
   * Available attributes are: `SUBREDDIT`, `MOD`, `AUTHOR`
 - Create `class EventFilter` using `enum ItemAttribute` to filter items by attribute, and `reverse` argument to filter all items except matches.

**Other:**

 - Updated docstrings and typing.
 - Fixed usage of `apraw.models.Comment.created_utc` due to errors with ReactivePy.

**Tests:**

 - Add `test_banhammer_meta` to test inner-workings of metaclass and decorators.