### PR TITLE
Fix Reverse Event Filters, Use Discord.py Event Loop

### DIFF
--- a/banhammer/banhammer.py
+++ b/banhammer/banhammer.py
@@ -73,9 +73,9 @@ class Banhammer(metaclass=BanhammerMeta):
         self._counter = counter
 
         self.subreddits = list()
+        self.loop = getattr(self, "loop", None) or asyncio.get_event_loop()
 
         self._event_handlers = getattr(self, "_event_handlers", list())
-        self._loop = asyncio.get_event_loop()
 
     async def add_subreddits(self, *subs):
         """
@@ -529,4 +529,4 @@ class Banhammer(metaclass=BanhammerMeta):
             print(re.sub(r"\*\*(.+)\*\*", r"{}\1{}".format(BOLD, END), f.read()))
             print("")
 
-        self._loop.create_task(self.send_items())
+        self.loop.create_task(self.send_items())

--- a/banhammer/models/event_handler.py
+++ b/banhammer/models/event_handler.py
@@ -36,27 +36,20 @@ class EventFilter:
         if not self._values:
             return True
 
+        match = True
+
         if self._attribute == ItemAttribute.MOD:
             if item.type != "mod action":
                 return False
             mod_name = await item.get_author_name()
-            if not any(mod_name.lower() == str(v).lower() for v in self._values):
-                return False
-            elif self._reverse:
-                return False
+            match = not any(mod_name.lower() == str(v).lower() for v in self._values)
         elif self._attribute == ItemAttribute.AUTHOR:
             author_name = await item.get_author_name()
-            if not any(author_name.lower() == str(v).lower() for v in self._values):
-                return False
-            elif self._reverse:
-                return False
+            match = not any(author_name.lower() == str(v).lower() for v in self._values)
         elif self._attribute == ItemAttribute.SUBREDDIT:
-            if not any(str(item.subreddit).lower() == str(v).lower() for v in self._values):
-                return False
-            elif self._reverse:
-                return False
+            match = not any(str(item.subreddit).lower() == str(v).lower() for v in self._values)
 
-        return True
+        return (not self._reverse and match) or (self._reverse and not match)
 
     def is_subreddit_valid(self, subreddit: 'Subreddit'):
         return self._attribute != ItemAttribute.SUBREDDIT or any(


### PR DESCRIPTION
 - Refactor `Banhammer._loop` to `loop` and use default loop from inherited classes if available.
 - Simplify evaluation of event filters and fix `reverse` functionality.