### PR TITLE
[FIX/ENHANCEMENT] Reaction Comments and Shortened Embed

### DIFF
--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -237,7 +237,7 @@ class MessageBuilder:
             text = repr(reaction).replace(str(reaction) + " | ", "")
             if reaction.reply:
                 text.replace(" | reply", "")
-                text += f"\n\n**Reply**\n>>> {reaction.reply}"
+                text += f"\n\n**Reply**\n>>> {reaction.reply.splitlines()[0]}"
                 fields.append({"name": str(reaction), "value": text})
             else:
                 fields = [{"name": str(reaction), "value": text}, *fields]

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -234,7 +234,9 @@ class MessageBuilder:
 
         fields = list()
         for reaction in subreddit.reactions:
-            title = f"{reaction.__comments__.splitlines()[0].replace('#', '', 1).strip().title()}: {reaction}" if reaction.__comments__ else f"`{reaction}`"
+            name = ' '.join(w.title() if w.islower() else w for w in reaction.__comments__.splitlines()
+                            [0].replace('#', '', 1).strip().split()) if reaction.__comments__ else ""
+            title = f"{name}: {reaction}" if name else f"`{reaction}`"
             text = repr(reaction).replace(str(reaction) + " | ", "")
 
             if reaction.reply:

--- a/banhammer/models/message_builder.py
+++ b/banhammer/models/message_builder.py
@@ -234,13 +234,15 @@ class MessageBuilder:
 
         fields = list()
         for reaction in subreddit.reactions:
+            title = f"{reaction.__comments__.splitlines()[0].replace('#', '', 1).strip().title()}: {reaction}" if reaction.__comments__ else f"`{reaction}`"
             text = repr(reaction).replace(str(reaction) + " | ", "")
+
             if reaction.reply:
                 text.replace(" | reply", "")
                 text += f"\n\n**Reply**\n>>> {reaction.reply.splitlines()[0]}"
-                fields.append({"name": str(reaction), "value": text})
+                fields.append({"name": title, "value": text})
             else:
-                fields = [{"name": str(reaction), "value": text}, *fields]
+                fields = [{"name": title, "value": text}, *fields]
         for field in fields:
             embed.add_field(**field)
 

--- a/banhammer/utils/yaml.py
+++ b/banhammer/utils/yaml.py
@@ -59,13 +59,17 @@ def get_list(str):
 
     dicts = list()
     s = ""
+    comments = list()
     for line in str.splitlines():
         line = strip(line)
         if line.startswith("-"):
-            dicts.append(get_dict(s))
+            d = get_dict(s)
+            d["__comments__"] = "\n".join(comments)
+            dicts.append(d)
             s = ""
-        elif strip(line).startswith("#"):
-            continue
+            comments = list()
+        elif line.startswith("#"):
+            comments.append(line)
         else:
             s += "\n" + line
 


### PR DESCRIPTION
Fixes #56 

 - Retaining comments parsed in YAML with the `__comments__` key.
 - Using first line of comment to generate reaction embed titles.
 - Surround reaction emojis with \`\` if standalone for improved mobile readability.